### PR TITLE
HOTFIX: Adding correct validator for login

### DIFF
--- a/utils/validators.js
+++ b/utils/validators.js
@@ -40,7 +40,7 @@ module.exports.validateLoginInput = (username, password) => {
   }
 
   if (password === "") {
-    errors.username = "Password must not be empty";
+    errors.password = "Password must not be empty";
   }
 
   return {


### PR DESCRIPTION
Amended validator logic for `validateLoginInput`. The empty password check was incorrectly reading the username value, rather than the password.