### PR TITLE
fix: Returning empty array on error

### DIFF
--- a/graphql/resolvers/posts.js
+++ b/graphql/resolvers/posts.js
@@ -10,7 +10,8 @@ module.exports = {
         const posts = await Post.find().sort({ createdAt: -1 });
         return posts;
       } catch (err) {
-        throw new Error(err);
+        console.error(err);
+        return [];
       }
     },
     getPost: async (_, { postId }) => {


### PR DESCRIPTION
**!! -- RELATED TO: [https://github.com/liuqibasixseveneight/Codesplanation.Client/pull/14](https://github.com/liuqibasixseveneight/Codesplanation.Client/pull/14) -- !!**

- Amended `getPosts` API to return an empty array if there is an error
